### PR TITLE
Set minimum python version to 3.7.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
dataclasses were introduced in 3.7 and I hope
to one day support freezing them too.