### PR TITLE
fix immutability test.

### DIFF
--- a/src/freeze/freeze.py
+++ b/src/freeze/freeze.py
@@ -172,5 +172,8 @@ def _frozen(obj):
 
 
 def _is_immutable(obj) -> bool:
-    hash_attr = getattr(obj, "__hash__", None)
-    return callable(hash_attr)
+    try:
+        _ = hash(obj)
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
This commit fixes an issue where an object that does
implement __hash__ but has it raise an exception
internally could potentially be considered immutable.

Currently the only case I'm aware of is tuple that will
raise an exception when __hash__ is called if one of
its values does not implement hash.

But fortunately this didn't really cause an issue because
tuples are always converted into FLists regardless of their
hashability.